### PR TITLE
Allow ending statements with newlines.

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -44,6 +44,8 @@ func (l *Lexer) NextToken() *token.Token {
 	l.skipWhitespace()
 
 	switch l.ch {
+	case '\n':
+		tok = newToken(token.NEWLINE, l.ch)
 	case '-':
 		tok = newToken(token.MINUS, l.ch)
 	case '*':
@@ -132,10 +134,7 @@ func (l *Lexer) NextToken() *token.Token {
 }
 
 func (l *Lexer) skipWhitespace() {
-	for l.ch == ' ' || l.ch == '\t' || l.ch == '\n' || l.ch == '\r' {
-		if l.ch == '\n' {
-			l.line++
-		}
+	for l.ch == ' ' || l.ch == '\t' || l.ch == '\r' {
 		l.advance()
 	}
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -185,7 +185,7 @@ func (p *Parser) parseExpressionStatement() *ast.ExpressionStatement {
 
 	stmt.Expression = p.parseExpression(LOWEST)
 
-	if p.peekTokenIs(token.SEMICOLON) {
+	if p.peekTokenIs(token.SEMICOLON) || p.peekTokenIs(token.NEWLINE) {
 		p.nextToken()
 	}
 

--- a/token/token.go
+++ b/token/token.go
@@ -43,6 +43,7 @@ const (
 	// Delimiters.
 	COMMA     TokenType = ","
 	SEMICOLON TokenType = ";"
+	NEWLINE   TokenType = "\n"
 
 	LPAREN   TokenType = "("
 	RPAREN   TokenType = ")"


### PR DESCRIPTION
Added token type `NEWLINE`.
Added newlines to `parseStatementExpression`
I forgot `parseReturnStatement`.
:)